### PR TITLE
Fixes typo in length() method

### DIFF
--- a/SimpleString.php
+++ b/SimpleString.php
@@ -518,12 +518,12 @@ class SimpleString
     }
     
     /**
-     * Returns the lenght of a string
+     * Returns the length of a string
      * 
      * @access public
-     * @return int String lenght
+     * @return int String length
      */
-    public function lenght()
+    public function length()
     {
         return strlen($this->string);
     }

--- a/docs/_SimpleString.class.html
+++ b/docs/_SimpleString.class.html
@@ -83,7 +83,7 @@ eliminate the problems of unorganized function names.</p>
 <dd><a class="method public" href="#%5CSimpleString::contains()">contains</a></dd>
 <dd><a class="method public" href="#%5CSimpleString::emphasize()">emphasize</a></dd>
 <dd><a class="method public" href="#%5CSimpleString::intersect()">intersect</a></dd>
-<dd><a class="method public" href="#%5CSimpleString::lenght()">lenght</a></dd>
+<dd><a class="method public" href="#%5CSimpleString::length()">length</a></dd>
 <dd><a class="method public" href="#%5CSimpleString::prepend()">prepend</a></dd>
 <dd><a class="method public" href="#%5CSimpleString::removeDelimiters()">removeDelimiters</a></dd>
 <dd><a class="method public" href="#%5CSimpleString::removeDuplicates()">removeDuplicates</a></dd>
@@ -462,22 +462,22 @@ built-in PHP string functions.</p>
 <div class="clear"></div>
 </div>
 </div>
-<a id="\SimpleString::lenght()"></a><h4 class="method public">lenght<div class="to-top"><a href="#SimpleString">jump to class</a></div>
+<a id="\SimpleString::length()"></a><h4 class="method public">length<div class="to-top"><a href="#SimpleString">jump to class</a></div>
 </h4>
 <div class="method">
-<code><span class="highlight">lenght</span><span class="nb-faded-text">(
+<code><span class="highlight">length</span><span class="nb-faded-text">(
           
           )
         </span>
         :
-        int</code><p class="short-description">Returns the lenght of a string</p>
+        int</code><p class="short-description">Returns the length of a string</p>
 <div class="long-description">
 </div>
 <div class="api-section">
 <h5 class="output">Output</h5>
 <dl class="return-info">
 <dt>int</dt>
-<dd><em>String lenght</em></dd>
+<dd><em>String length</em></dd>
 </dl>
 <div class="clear"></div>
 </div>

--- a/docs/structure.xml
+++ b/docs/structure.xml
@@ -363,13 +363,13 @@ built-in PHP string functions.</description>
         </argument>
       </method>
       <method final="false" abstract="false" static="false" visibility="public" line="419">
-        <name>lenght</name>
+        <name>length</name>
         <docblock>
-          <description>Returns the lenght of a string</description>
+          <description>Returns the length of a string</description>
           <long-description>
 </long-description>
           <tag name="access" description="public" line="413"/>
-          <tag name="return" description="String lenght" type="int" line="413">
+          <tag name="return" description="String length" type="int" line="413">
             <type by_reference="false">int</type>
           </tag>
         </docblock>

--- a/tests/SimpleStringTest.php
+++ b/tests/SimpleStringTest.php
@@ -219,10 +219,10 @@ class SimpleStringTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('sit amet', $string->__toString());
     }
 
-    public function testLenght()
+    public function testLength()
     {
         $string = new SimpleString('Lorem ipsum dolor sit amet');
-        $this->assertEquals(26, $string->lenght());
+        $this->assertEquals(26, $string->length());
     }
 
     public function testWords()


### PR DESCRIPTION
From lenght() to length(), also fixed in test and docs.
